### PR TITLE
Ability to fetch cache imports

### DIFF
--- a/pkg/cib/cib.go
+++ b/pkg/cib/cib.go
@@ -37,6 +37,8 @@ type Service interface {
 	GetBuildPlatform() *specs.Platform
 	// GetTargetPlatforms returns the list of target platforms for the image(s) being built.
 	GetTargetPlatforms() ([]*specs.Platform, error)
+	// GetCacheImports returns the list of external cache sources to use in the build.
+	GetCacheImports() ([]client.CacheOptionsEntry, error)
 	// GetIgnoreCache indicates whether the cache should be ignored.
 	GetIgnoreCache() bool
 

--- a/pkg/cib/vendor.go
+++ b/pkg/cib/vendor.go
@@ -18,6 +18,8 @@ const (
 	dockerignoreFilename = ".dockerignore"
 	keyImageResolveMode  = "image-resolve-mode"
 	keyFilename          = "filename"
+	keyCacheFrom         = "cache-from"    // for registry only. deprecated in favor of keyCacheImports
+	keyCacheImports      = "cache-imports" // JSON representation of []CacheOptionsEntry
 	keyTargetPlatform    = "platform"
 	keyNoCache           = "no-cache"
 )


### PR DESCRIPTION
# Overview
This PR adds `GetCacheImports` API to easily fetch the list of external cache sources to use in the build.

# Testing
- Automated tests pass