### PR TITLE
Publish a simple frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Package
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          tags: erichripko/simple-frontend
+          context: .
+
       - name: Install test runner
         run: curl -sSL "https://github.com/gotestyourself/gotestsum/releases/download/v1.6.2/gotestsum_1.6.2_linux_amd64.tar.gz" | sudo tar -xz -C /usr/local/bin gotestsum
 
@@ -38,3 +45,18 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
+
+      - name: Login to DockerHub
+        if: github.ref == 'ref/heads/main' && success()
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Release
+        if: github.ref == 'ref/heads/main' && success()
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: erichripko/simple-frontend
+          context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.15 as build
+WORKDIR /go/src/app
+ENV CGO_ENABLED=0
+COPY . .
+RUN go install -v ./...
+RUN touch /go/bin/header.Dockerfile /go/bin/footer.Dockerfile
+
+FROM scratch
+LABEL moby.buildkit.frontend.network.none="true"
+COPY --from=build \
+    /go/bin/header.Dockerfile \
+    /go/bin/footer.Dockerfile \
+    /go/bin/simple-frontend \
+    /
+ENTRYPOINT ["/simple-frontend"]
+LABEL \
+    org.opencontainers.image.authors="Eric Hripko" \
+    org.opencontainers.image.documentation="https://github.com/EricHripko/buildkit-fdk" \
+    org.opencontainers.image.source="https://github.com/EricHripko/buildkit-fdk.git"\
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.title="Simple BuildKit frontend" \
+    org.opencontainers.image.description="Frontend that concatenates user-specified Dockerfile with the pre-configured header and footer"

--- a/cmd/simple-frontend/main.go
+++ b/cmd/simple-frontend/main.go
@@ -1,0 +1,48 @@
+// Simple frontend that concatenates combines pre-configures Dockerfiles with
+// the one provided by the build context.
+package main
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/EricHripko/buildkit-fdk/pkg/dtp"
+
+	dockerfile "github.com/moby/buildkit/frontend/dockerfile/builder"
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/frontend/gateway/grpcclient"
+	"github.com/moby/buildkit/util/appcontext"
+	"github.com/sirupsen/logrus"
+)
+
+func build(ctx context.Context, c client.Client) (*client.Result, error) {
+	// Read vendored Dockerfiles
+	header, err := ioutil.ReadFile("header.Dockerfile")
+	if err != nil {
+		return nil, err
+	}
+	footer, err := ioutil.ReadFile("footer.Dockerfile")
+	if err != nil {
+		return nil, err
+	}
+
+	// Concatenate user-supplied Dockerfile with vendored ones
+	transform := func(dockerfile []byte) ([]byte, error) {
+		dockerfile = append(header, dockerfile...)
+		dockerfile = append(dockerfile, footer...)
+		return dockerfile, nil
+	}
+	if err := dtp.InjectDockerfileTransform(transform, c); err != nil {
+		return nil, err
+	}
+
+	// Pass control to the upstream Dockerfile frontend
+	return dockerfile.Build(ctx, c)
+}
+
+func main() {
+	if err := grpcclient.RunFromEnvironment(appcontext.Context(), build); err != nil {
+		logrus.Errorf("fatal error: %+v", err)
+		panic(err)
+	}
+}

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,5 @@
+# syntax=erichripko/ubuntu-dockerfile
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+    && rm -rf /var/lib/apt/lists/*

--- a/examples/frontend/Dockerfile
+++ b/examples/frontend/Dockerfile
@@ -1,0 +1,2 @@
+FROM erichripko/simple-frontend
+COPY header.Dockerfile footer.Dockerfile /

--- a/examples/frontend/footer.Dockerfile
+++ b/examples/frontend/footer.Dockerfile
@@ -1,0 +1,2 @@
+# Rely on the frontend to automatically attach license information
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/examples/frontend/header.Dockerfile
+++ b/examples/frontend/header.Dockerfile
@@ -1,0 +1,2 @@
+# Rely on the frontend to standardise the base image
+FROM ubuntu

--- a/examples/simple-frontend_test.go
+++ b/examples/simple-frontend_test.go
@@ -1,0 +1,72 @@
+package examples_test
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func build(t *testing.T, tag string, context string) {
+	// Arrange
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+	cmd := exec.Command(
+		"docker",
+		"build",
+		"-t",
+		tag,
+		context,
+	)
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+	cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+
+	// Act
+	err := cmd.Run()
+
+	// Assert
+	if err != nil {
+		t.Log("stdout: ", stdout.String())
+		t.Log("stderr: ", stderr.String())
+		t.Log(err)
+		t.Fail()
+	}
+}
+
+const (
+	tagTestFrontend = "erichripko/simple-frontend"
+	tagTestImage    = "erichripko/simple-frontend-test"
+)
+
+func TestSimpleFrontend(t *testing.T) {
+	// Arrange
+	build(t, tagTestFrontend, "frontend")
+
+	// Act
+	build(t, tagTestImage, ".")
+
+	// Assert
+	out, err := exec.Command( // Verify that header was injected
+		"docker",
+		"run",
+		tagTestImage,
+		"cat",
+		"/etc/lsb-release",
+	).Output()
+	require.Nil(t, err)
+	require.Contains(t, string(out), "Ubuntu")
+
+	out, err = exec.Command( // Verify that footer was injected
+		"docker",
+		"inspect",
+		tagTestImage,
+		"--format",
+		"{{index .Config.Labels \"org.opencontainers.image.licenses\"}}",
+	).Output()
+	require.Nil(t, err)
+	require.Equal(t, "Apache-2.0", strings.TrimSpace(string(out)))
+}

--- a/examples/simple-frontend_test.go
+++ b/examples/simple-frontend_test.go
@@ -38,8 +38,8 @@ func build(t *testing.T, tag string, context string) {
 }
 
 const (
-	tagTestFrontend = "erichripko/simple-frontend"
-	tagTestImage    = "erichripko/simple-frontend-test"
+	tagTestFrontend = "erichripko/ubuntu-dockerfile"
+	tagTestImage    = "erichripko/ubuntu-dockerfile-test"
 )
 
 func TestSimpleFrontend(t *testing.T) {


### PR DESCRIPTION
# Overview
Implement a simple frontend that concatenates user-supplied `Dockerfile` with a pre-configured header and footer. This PR also adds automated packaging and release of the sample frontend. 

# Testing
- New end-to-end test for the simple frontend
