### PR TITLE
Make it easier to identify multi-platform mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Frontend Development kit for BuildKit
 
+[![Go Report](https://goreportcard.com/badge/github.com/EricHripko/buildkit-fdk)](https://goreportcard.com/report/github.com/EricHripko/buildkit-fdk)
+![CI](https://github.com/EricHripko/buildkit-fdk/actions/workflows/ci.yml/badge.svg)
+[![codecov](https://codecov.io/gh/EricHripko/buildkit-fdk/branch/main/graph/badge.svg?token=HocgcUbyyD)](https://codecov.io/gh/EricHripko/buildkit-fdk)
+
 This repository houses the frontend Development Kit for [BuildKit](https://github.com/moby/buildkit).
 It aims to make the development of custom frontends easier by removing
 the unnecessary boilerplate. Generally speaking, there's _3_ ways to make use

--- a/pkg/cib/cib.go
+++ b/pkg/cib/cib.go
@@ -37,6 +37,8 @@ type Service interface {
 	GetBuildPlatform() *specs.Platform
 	// GetTargetPlatforms returns the list of target platforms for the image(s) being built.
 	GetTargetPlatforms() ([]*specs.Platform, error)
+	// GetIsMultiPlatform returns true if this is a multi-platform build and false otherwise.
+	GetIsMultiPlatform() (bool, error)
 	// GetCacheImports returns the list of external cache sources to use in the build.
 	GetCacheImports() ([]client.CacheOptionsEntry, error)
 	// GetIgnoreCache indicates whether the cache should be ignored.

--- a/pkg/cib/vendor.go
+++ b/pkg/cib/vendor.go
@@ -20,6 +20,7 @@ const (
 	keyFilename          = "filename"
 	keyCacheFrom         = "cache-from"    // for registry only. deprecated in favor of keyCacheImports
 	keyCacheImports      = "cache-imports" // JSON representation of []CacheOptionsEntry
+	keyMultiPlatform     = "multi-platform"
 	keyTargetPlatform    = "platform"
 	keyNoCache           = "no-cache"
 )


### PR DESCRIPTION
# Overview
This PR implements `GetIsMultiPlatform` method to make it easier to identify if multi-platform mode should be used.

# Other Changes
- Add badges to display project health

# Testing
- Covered by unit tests