### PR TITLE
Update mocks

### DIFF
--- a/pkg/cib/mock/cib.go
+++ b/pkg/cib/mock/cib.go
@@ -97,6 +97,21 @@ func (mr *MockServiceMockRecorder) GetBuildPlatform() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuildPlatform", reflect.TypeOf((*MockService)(nil).GetBuildPlatform))
 }
 
+// GetCacheImports mocks base method
+func (m *MockService) GetCacheImports() ([]client.CacheOptionsEntry, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCacheImports")
+	ret0, _ := ret[0].([]client.CacheOptionsEntry)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCacheImports indicates an expected call of GetCacheImports
+func (mr *MockServiceMockRecorder) GetCacheImports() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCacheImports", reflect.TypeOf((*MockService)(nil).GetCacheImports))
+}
+
 // GetCaps mocks base method
 func (m *MockService) GetCaps() apicaps.CapSet {
 	m.ctrl.T.Helper()
@@ -138,6 +153,21 @@ func (m *MockService) GetIgnoreCache() bool {
 func (mr *MockServiceMockRecorder) GetIgnoreCache() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIgnoreCache", reflect.TypeOf((*MockService)(nil).GetIgnoreCache))
+}
+
+// GetIsMultiPlatform mocks base method
+func (m *MockService) GetIsMultiPlatform() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIsMultiPlatform")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIsMultiPlatform indicates an expected call of GetIsMultiPlatform
+func (mr *MockServiceMockRecorder) GetIsMultiPlatform() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsMultiPlatform", reflect.TypeOf((*MockService)(nil).GetIsMultiPlatform))
 }
 
 // GetMarshalOpts mocks base method

--- a/pkg/cib/service_test.go
+++ b/pkg/cib/service_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// Ensure that mocks are up-to-date
+var _ Service = &cib_mock.MockService{}
+
 func TestNewServiceSucceeds(t *testing.T) {
 	// Act
 	build := NewService(context.Background(), nil)


### PR DESCRIPTION
# Overview
Mocks weren't updated with the interfaces changes, which caused downstream project issues. This PR updates the mocks and adds a build-time check to ensure that they never go out-of-date again.